### PR TITLE
fix julia package permissions, chown .julia to vagrant

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -187,9 +187,9 @@ add-apt-repository -y ppa:staticfloat/julia-deps
 apt-get -y -qq update || true
 apt-get -y -qq install julia || true
 # Install iJulia
-# DON'T INSTALL IJULIA YET; IT IS A SPACE HOG. AND THIS LEADS TO PERMISSIONS
-# PROBLEMS
 julia --eval 'Pkg.add("IJulia")'
+# since installed w/ sudo, must change permissions back to the default user.
+chown -R vagrant /home/vagrant/.julia
 
 printf '************************************************************************\n'
 printf '*\n*\n* DONE PROVISIONING! \n*\n*\n'


### PR DESCRIPTION
this fixes package permissions and allows the vagrant user to use julia
as expected, installing packages in the vagrant home directory without needing
to run julia as the super user.
