### PR TITLE
Back to aptitude

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -166,33 +166,36 @@ __MSG__
 echo 'deb http://software.ligo.org/lscsoft/debian wheezy contrib' > /etc/apt/sources.list.d/lscsoft.list
 echo 'deb-src http://software.ligo.org/lscsoft/debian wheezy contrib' > /etc/apt/sources.list.d/lscsoft-src.list
 # quietly installing untrusted packages: https://anothersysadmin.wordpress.com/2008/12/30/tip-installing-untrusted-packages-without-confirmation-on-debian/
-# aptitude --no-gui -y -q update || true
-# aptitude --no-gui -o Aptitude::Cmdline::ignore-trust-violations=true -y -q full-upgrade || true
-# aptitude --no-gui -o Aptitude::Cmdline::ignore-trust-violations=true -y -q install lscsoft-archive-keyring || true
-# aptitude --no-gui -o Aptitude::Cmdline::ignore-trust-violations=true -y -q install lscsoft-all || true
-# aptitude --no-gui -o Aptitude::Cmdline::ignore-trust-violations=true -y -q install nds2-client || true
-# aptitude --no-gui -o Aptitude::Cmdline::ignore-trust-violations=true -y -q install lalapps || true
+aptitude --no-gui -y -q update || true
+aptitude --no-gui -o Aptitude::Cmdline::ignore-trust-violations=true -y -q full-upgrade || true
+aptitude --no-gui -o Aptitude::Cmdline::ignore-trust-violations=true -y -q install lscsoft-archive-keyring || true
+aptitude --no-gui -o Aptitude::Cmdline::ignore-trust-violations=true -y -q install lscsoft-all || true
+aptitude --no-gui -o Aptitude::Cmdline::ignore-trust-violations=true -y -q install lscsoft-glue || true
+aptitude --no-gui -o Aptitude::Cmdline::ignore-trust-violations=true -y -q install python-glue || true
+aptitude --no-gui -o Aptitude::Cmdline::ignore-trust-violations=true -y -q install nds2-client || true
+aptitude --no-gui -o Aptitude::Cmdline::ignore-trust-violations=true -y -q install python-nds2-client || true
+aptitude --no-gui -o Aptitude::Cmdline::ignore-trust-violations=true -y -q install lalapps || true
 
 # THE BELOW SCRIPTS BUILD FROM SOURCE
-# set paths for PKG_CONFIG <-- THIS IS PROBABLY UNNECESSARY OFF OF TRAVIS
-# export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${VIRTUAL_ENV}/lib/pkgconfig
-# build a newer version of swig
-bash $HOME/build-with-autotools.sh swig-${SWIG_VERSION} ${SWIG_}
-# build FFTW3 (double and float)
-bash $HOME/build-with-autotools.sh fftw-${FFTW_VERSION} ${FFTW} --enable-shared=yes
-bash $HOME/build-with-autotools.sh fftw-${FFTW_VERSION}-float ${FFTW} --enable-shared=yes --enable-float
-# build frame libraries
-bash $HOME/build-with-autotools.sh ldas-tools-${LDAS_TOOLS_VERSION} ${LDAS_TOOLS}
-bash $HOME/build-with-autotools.sh libframe-${LIBFRAME_VERSION} ${LIBFRAME}
-# build LAL packages
-bash $HOME/build-with-autotools.sh lal-${LAL_VERSION} ${LAL} --enable-swig-python
-bash $HOME/build-with-autotools.sh lalframe-${LALFRAME_VERSION} ${LALFRAME} --enable-swig-python
-# build NDS2 client
-bash $HOME/build-with-autotools.sh nds2-client-${NDS2_CLIENT_VERSION} ${NDS2_CLIENT} --disable-swig-java --disable-mex-matlab
-# # install cython to speed up scipy build
-# pip install -q --install-option="--no-cython-compile" Cython
-# # install testing dependencies
-# pip install -q coveralls "pytest>=2.8" unittest2
+# # set paths for PKG_CONFIG <-- THIS IS PROBABLY UNNECESSARY OFF OF TRAVIS
+# # export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${VIRTUAL_ENV}/lib/pkgconfig
+# # build a newer version of swig
+# bash $HOME/build-with-autotools.sh swig-${SWIG_VERSION} ${SWIG_}
+# # build FFTW3 (double and float)
+# bash $HOME/build-with-autotools.sh fftw-${FFTW_VERSION} ${FFTW} --enable-shared=yes
+# bash $HOME/build-with-autotools.sh fftw-${FFTW_VERSION}-float ${FFTW} --enable-shared=yes --enable-float
+# # build frame libraries
+# bash $HOME/build-with-autotools.sh ldas-tools-${LDAS_TOOLS_VERSION} ${LDAS_TOOLS}
+# bash $HOME/build-with-autotools.sh libframe-${LIBFRAME_VERSION} ${LIBFRAME}
+# # build LAL packages
+# bash $HOME/build-with-autotools.sh lal-${LAL_VERSION} ${LAL} --enable-swig-python
+# bash $HOME/build-with-autotools.sh lalframe-${LALFRAME_VERSION} ${LALFRAME} --enable-swig-python
+# # build NDS2 client
+# bash $HOME/build-with-autotools.sh nds2-client-${NDS2_CLIENT_VERSION} ${NDS2_CLIENT} --disable-swig-java --disable-mex-matlab
+# # # install cython to speed up scipy build
+# # pip install -q --install-option="--no-cython-compile" Cython
+# # # install testing dependencies
+# # pip install -q coveralls "pytest>=2.8" unittest2
 
 cat <<__MSG__
 ***********************************************************
@@ -226,9 +229,9 @@ cat <<__MSG__
 ***********************************************************
 __MSG__
 # gwpy requirements
-echo $GLUE > $HOME/requirements.txt
-echo $DQSEGDB >> $HOME/requirements.txt
-$NEW_PIP install -r $HOME/requirements.txt
+# echo $GLUE > $HOME/requirements.txt
+# echo $DQSEGDB >> $HOME/requirements.txt
+# $NEW_PIP install -r $HOME/requirements.txt
 $NEW_PIP install gwpy
 
 cat <<__MSG__

--- a/provision.sh
+++ b/provision.sh
@@ -6,12 +6,13 @@
 echo "set grub-pc/install_devices /dev/sda" | debconf-communicate
 
 # move build-with-autotools file around as needed.
+export HOME="/home/vagrant"
 if [ -e /vagrant/build-with-autotools.sh ]; then
     echo build-with-autotools.sh found in vagrant directory.
-    cp /vagrant/build-with-autotools.sh /home/vagrant/build-with-autotools.sh
+    cp /vagrant/build-with-autotools.sh $HOME/build-with-autotools.sh
 elif [ -e /tmp/build-with-autotools.sh ]; then
     echo build-with-autotools.sh found in packer directory.
-    cp /tmp/build-with-autotools.sh /home/vagrant/build-with-autotools.sh
+    cp /tmp/build-with-autotools.sh $HOME/build-with-autotools.sh
 else
     echo build-with-autotools.sh not found.
     exit 1
@@ -19,6 +20,7 @@ fi
 
 # environmental variables
 export DEBIAN_FRONTEND=noninteractive
+export NEW_PIP="/usr/local/bin/pip" # updating pip changes the path, ergo this
 export SWIG_VERSION="3.0.8"
 export FFTW_VERSION="3.3.4"
 export LAL_VERSION="6.15.0"
@@ -26,7 +28,8 @@ export LALFRAME_VERSION="1.3.0"
 export LIBFRAME_VERSION="8.20"
 export LDAS_TOOLS_VERSION="2.4.1"
 export NDS2_CLIENT_VERSION="0.10.4"
-export GLUE_VERSION="1.49"
+export GLUE_VERSION="1.49.1"
+export DQSEGDB_VERSION="1.2.2"
 export SWIG_="https://github.com/swig/swig/archive/rel-${SWIG_VERSION}.tar.gz"
 export FFTW="http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz"
 export LDAS_TOOLS="http://software.ligo.org/lscsoft/source/ldas-tools-${LDAS_TOOLS_VERSION}.tar.gz"
@@ -35,6 +38,7 @@ export LAL="http://software.ligo.org/lscsoft/source/lalsuite/lal-${LAL_VERSION}.
 export LALFRAME="http://software.ligo.org/lscsoft/source/lalsuite/lalframe-${LALFRAME_VERSION}.tar.gz"
 export NDS2_CLIENT="http://software.ligo.org/lscsoft/source/nds2-client-${NDS2_CLIENT_VERSION}.tar.gz"
 export GLUE="http://software.ligo.org/lscsoft/source/glue-${GLUE_VERSION}.tar.gz"
+export DQSEGDB="http://software.ligo.org/lscsoft/source/dqsegdb-${DQSEGDB_VERSION}.tar.gz"
 
 cat <<__MSG__
 ***********************************************************
@@ -173,20 +177,18 @@ echo 'deb-src http://software.ligo.org/lscsoft/debian wheezy contrib' > /etc/apt
 # set paths for PKG_CONFIG <-- THIS IS PROBABLY UNNECESSARY OFF OF TRAVIS
 # export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${VIRTUAL_ENV}/lib/pkgconfig
 # build a newer version of swig
-bash /home/vagrant/build-with-autotools.sh swig-${SWIG_VERSION} ${SWIG_}
+bash $HOME/build-with-autotools.sh swig-${SWIG_VERSION} ${SWIG_}
 # build FFTW3 (double and float)
-bash /home/vagrant/build-with-autotools.sh fftw-${FFTW_VERSION} ${FFTW} --enable-shared=yes
-bash /home/vagrant/build-with-autotools.sh fftw-${FFTW_VERSION}-float ${FFTW} --enable-shared=yes --enable-float
+bash $HOME/build-with-autotools.sh fftw-${FFTW_VERSION} ${FFTW} --enable-shared=yes
+bash $HOME/build-with-autotools.sh fftw-${FFTW_VERSION}-float ${FFTW} --enable-shared=yes --enable-float
 # build frame libraries
-bash /home/vagrant/build-with-autotools.sh ldas-tools-${LDAS_TOOLS_VERSION} ${LDAS_TOOLS}
-bash /home/vagrant/build-with-autotools.sh libframe-${LIBFRAME_VERSION} ${LIBFRAME}
+bash $HOME/build-with-autotools.sh ldas-tools-${LDAS_TOOLS_VERSION} ${LDAS_TOOLS}
+bash $HOME/build-with-autotools.sh libframe-${LIBFRAME_VERSION} ${LIBFRAME}
 # build LAL packages
-bash /home/vagrant/build-with-autotools.sh lal-${LAL_VERSION} ${LAL} --enable-swig-python
-bash /home/vagrant/build-with-autotools.sh lalframe-${LALFRAME_VERSION} ${LALFRAME} --enable-swig-python
+bash $HOME/build-with-autotools.sh lal-${LAL_VERSION} ${LAL} --enable-swig-python
+bash $HOME/build-with-autotools.sh lalframe-${LALFRAME_VERSION} ${LALFRAME} --enable-swig-python
 # build NDS2 client
-bash /home/vagrant/build-with-autotools.sh nds2-client-${NDS2_CLIENT_VERSION} ${NDS2_CLIENT} --disable-swig-java --disable-mex-matlab
-# build glue package
-bash /home/vagrant/build-with-autotools.sh glue-&{GLUE_VERSION} ${GLUE}
+bash $HOME/build-with-autotools.sh nds2-client-${NDS2_CLIENT_VERSION} ${NDS2_CLIENT} --disable-swig-java --disable-mex-matlab
 # # install cython to speed up scipy build
 # pip install -q --install-option="--no-cython-compile" Cython
 # # install testing dependencies
@@ -205,14 +207,14 @@ __MSG__
 pip install -q --upgrade pip
 # add security stuff for gwpy to prevent InsecurePlatformWarning
 # see: http://stackoverflow.com/questions/29134512/insecureplatformwarning-a-true-sslcontext-object-is-not-available-this-prevent
-/usr/local/bin/pip install -q requests[security]
+$NEW_PIP install -q requests[security]
 # build and install numpy first
-/usr/local/bin/pip install -q "numpy>=1.9.1"
+$NEW_PIP install -q "numpy>=1.9.1"
 # install ipython and jupyter
-# /usr/local/bin/pip install -q ipython
+# $NEW_PIP install -q ipython
 # but do it using apt-get instead
 apt-get install -y -qq ipython
-/usr/local/bin/pip install -q jupyter
+$NEW_PIP install -q jupyter
 
 cat <<__MSG__
 ***********************************************************
@@ -223,7 +225,11 @@ cat <<__MSG__
 *
 ***********************************************************
 __MSG__
-/usr/local/bin/pip install gwpy
+# gwpy requirements
+echo $GLUE > $HOME/requirements.txt
+echo $DQSEGDB >> $HOME/requirements.txt
+$NEW_PIP install -r $HOME/requirements.txt
+$NEW_PIP install gwpy
 
 cat <<__MSG__
 ***********************************************************
@@ -260,7 +266,7 @@ apt-get -y -qq install julia || true
 # Install iJulia
 julia --eval 'Pkg.add("IJulia")'
 # since installed w/ sudo, must change permissions back to the default user.
-chown -R vagrant /home/vagrant
+chown -R vagrant $HOME
 
 cat <<__MSG__
 ************************************************************

--- a/provision.sh
+++ b/provision.sh
@@ -26,6 +26,7 @@ export LALFRAME_VERSION="1.3.0"
 export LIBFRAME_VERSION="8.20"
 export LDAS_TOOLS_VERSION="2.4.1"
 export NDS2_CLIENT_VERSION="0.10.4"
+export GLUE_VERSION="1.49"
 export SWIG_="https://github.com/swig/swig/archive/rel-${SWIG_VERSION}.tar.gz"
 export FFTW="http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz"
 export LDAS_TOOLS="http://software.ligo.org/lscsoft/source/ldas-tools-${LDAS_TOOLS_VERSION}.tar.gz"
@@ -33,6 +34,7 @@ export LIBFRAME="http://software.ligo.org/lscsoft/source/libframe-${LIBFRAME_VER
 export LAL="http://software.ligo.org/lscsoft/source/lalsuite/lal-${LAL_VERSION}.tar.gz"
 export LALFRAME="http://software.ligo.org/lscsoft/source/lalsuite/lalframe-${LALFRAME_VERSION}.tar.gz"
 export NDS2_CLIENT="http://software.ligo.org/lscsoft/source/nds2-client-${NDS2_CLIENT_VERSION}.tar.gz"
+export GLUE="http://software.ligo.org/lscsoft/source/glue-${GLUE_VERSION}.tar.gz"
 
 cat <<__MSG__
 ***********************************************************
@@ -183,6 +185,8 @@ bash /home/vagrant/build-with-autotools.sh lal-${LAL_VERSION} ${LAL} --enable-sw
 bash /home/vagrant/build-with-autotools.sh lalframe-${LALFRAME_VERSION} ${LALFRAME} --enable-swig-python
 # build NDS2 client
 bash /home/vagrant/build-with-autotools.sh nds2-client-${NDS2_CLIENT_VERSION} ${NDS2_CLIENT} --disable-swig-java --disable-mex-matlab
+# build glue package
+bash /home/vagrant/build-with-autotools.sh glue-&{GLUE_VERSION} ${GLUE}
 # # install cython to speed up scipy build
 # pip install -q --install-option="--no-cython-compile" Cython
 # # install testing dependencies


### PR DESCRIPTION
Forsake a source install.

Submit to the mystery of the LSCSOFT apt repository.

Install `python-nds2`, `lscsoft-glue`, and `python-glue` using aptitude.

Also, refactor things to reflect our attempts at building from source, in case we ever decide to try that again. And reduce "magic paths" in the provisioning script.
